### PR TITLE
Remove terser-webpack-plugin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "postcss-preset-env": "^6.7.0",
     "postcss-pxtorem": "^5.1.1",
     "style-loader": "^2.0.0",
-    "terser-webpack-plugin": "^5.1.1",
     "webpack": "^5.22.0",
     "webpack-cli": "^4.5.0",
     "webpack-dev-server": "^3.11.2"

--- a/webpack.build.config.js
+++ b/webpack.build.config.js
@@ -1,7 +1,6 @@
 const webpack = require('webpack')
 const path = require('path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const TerserPlugin = require('terser-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 // Any directories you will be adding code/files into, need to be added to this array so webpack will pick them up
@@ -56,8 +55,4 @@ module.exports = {
     chunks: false,
     modules: false
   },
-  optimization: {
-    minimize: true,
-    minimizer: [new TerserPlugin()]
-  }
 }


### PR DESCRIPTION
This is quoted from their [site](https://webpack.js.org/plugins/terser-webpack-plugin/#getting-started).

"If you are using webpack v5 or above you do not need to install this plugin. Webpack v5 comes with the latest terser-webpack-plugin out of the box."

In your package.json, you are using "webpack": "^5.22.0" which means that you no longer need to import terser. 😄 